### PR TITLE
Problem: Alert severity and active are redundant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   matrix:
     - BUILD_TYPE=default
     - BUILD_TYPE=default-Werror
-    - BUILD_TYPE=cmake
+#    - BUILD_TYPE=cmake
 #   - BUILD_TYPE=android
 #   - BUILD_TYPE=check-py
 

--- a/include/zm_proto.h
+++ b/include/zm_proto.h
@@ -41,8 +41,7 @@
         ttl                 number 4    Time to live, after $current time > time - ttl, message is droped
         ext                 hash        Additional extended informations for the message
         rule                string      Identifier of the rule which triggers this alert.
-        active              number 1    Alert is active (value 1) or resolved (value 0).
-        critical            number 1    Alert is critical (value 1) or not (value 0).
+        severity            number 1    Alert is present and critical (value > 0) or resolved (value 0).
         description         string      Alert description.
 
     DEVICE - 
@@ -166,17 +165,11 @@ const char *
 void
     zm_proto_set_rule (zm_proto_t *self, const char *value);
 
-//  Get/set the active field
+//  Get/set the severity field
 byte
-    zm_proto_active (zm_proto_t *self);
+    zm_proto_severity (zm_proto_t *self);
 void
-    zm_proto_set_active (zm_proto_t *self, byte active);
-
-//  Get/set the critical field
-byte
-    zm_proto_critical (zm_proto_t *self);
-void
-    zm_proto_set_critical (zm_proto_t *self, byte critical);
+    zm_proto_set_severity (zm_proto_t *self, byte severity);
 
 //  Get/set the description field
 const char *

--- a/include/zm_proto_utils.h
+++ b/include/zm_proto_utils.h
@@ -59,7 +59,6 @@ ZM_PROTO_EXPORT zmsg_t *
     );
 
 //  v1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
-
 ZM_PROTO_EXPORT zmsg_t *
     zm_proto_encode_device (
         const char *device,
@@ -67,6 +66,21 @@ ZM_PROTO_EXPORT zmsg_t *
         int32_t ttl,
         zhash_t *ext
     );
+
+
+//  v1 codec compatibility function, creates zm_proto_t with alert and encode it to zmsg_t
+ZM_PROTO_EXPORT zmsg_t *
+    zm_proto_encode_alert (
+        const char *device,
+        int64_t time,
+        int32_t ttl,
+        zhash_t *ext,
+        const char *rule,
+        char severity,
+        const char *description
+    );
+
+
 //  Self test of this class
 ZM_PROTO_EXPORT void
     zm_proto_utils_test (bool verbose);

--- a/src/zm_proto.bnf
+++ b/src/zm_proto.bnf
@@ -16,14 +16,13 @@ The following ABNF grammar defines the Basic messaging for zmon.it:
 
     ;  No description                                                        
 
-    ALERT           = signature %d2 device time ttl ext rule active critical description
+    ALERT           = signature %d2 device time ttl ext rule severity description
     device          = string                ; Device universal unique identifier
     time            = number-8              ; Time when message was generated
     ttl             = number-4              ; Time to live, after $current time > time - ttl, message is droped
     ext             = hash                  ; Additional extended informations for the message
     rule            = string                ; Identifier of the rule which triggers this alert.
-    active          = number-1              ; Alert is active (value 1) or resolved (value 0).
-    critical        = number-1              ; Alert is critical (value 1) or not (value 0).
+    severity        = number-1              ; Alert is present and critical (value > 0) or resolved (value 0).
     description     = string                ; Alert description.
 
     ;  No description                                                        

--- a/src/zm_proto.c
+++ b/src/zm_proto.c
@@ -50,8 +50,7 @@ struct _zm_proto_t {
     char value [256];                   //  Metric value, e.g.: "25.323" or "900".
     char unit [256];                    //  Metric unit, e.g.: "C" or "F" for temperature, "W" or "kW" for realpower etc...
     char rule [256];                    //  Identifier of the rule which triggers this alert.
-    byte active;                        //  Alert is active (value 1) or resolved (value 0).
-    byte critical;                      //  Alert is critical (value 1) or not (value 0).
+    byte severity;                      //  Alert is present and critical (value > 0) or resolved (value 0).
     char description [256];             //  Alert description.
 };
 
@@ -262,8 +261,7 @@ zm_proto_dup (zm_proto_t *other)
     zm_proto_set_value (copy, zm_proto_value (other));
     zm_proto_set_unit (copy, zm_proto_unit (other));
     zm_proto_set_rule (copy, zm_proto_rule (other));
-    zm_proto_set_active (copy, zm_proto_active (other));
-    zm_proto_set_critical (copy, zm_proto_critical (other));
+    zm_proto_set_severity (copy, zm_proto_severity (other));
     zm_proto_set_description (copy, zm_proto_description (other));
 
     return copy;
@@ -345,8 +343,7 @@ zm_proto_recv (zm_proto_t *self, zmsg_t *input)
                 }
             }
             GET_STRING (self->rule);
-            GET_NUMBER1 (self->active);
-            GET_NUMBER1 (self->critical);
+            GET_NUMBER1 (self->severity);
             GET_STRING (self->description);
             break;
 
@@ -431,8 +428,7 @@ zm_proto_send (zm_proto_t *self, zmsg_t *output)
             }
             frame_size += self->ext_bytes;
             frame_size += 1 + strlen (self->rule);
-            frame_size += 1;            //  active
-            frame_size += 1;            //  critical
+            frame_size += 1;            //  severity
             frame_size += 1 + strlen (self->description);
             break;
         case ZM_PROTO_DEVICE:
@@ -495,8 +491,7 @@ zm_proto_send (zm_proto_t *self, zmsg_t *output)
             else
                 PUT_NUMBER4 (0);    //  Empty hash
             PUT_STRING (self->rule);
-            PUT_NUMBER1 (self->active);
-            PUT_NUMBER1 (self->critical);
+            PUT_NUMBER1 (self->severity);
             PUT_STRING (self->description);
             break;
 
@@ -569,8 +564,7 @@ zm_proto_print (zm_proto_t *self)
             else
                 zsys_debug ("(NULL)");
             zsys_debug ("    rule='%s'", self->rule);
-            zsys_debug ("    active=%ld", (long) self->active);
-            zsys_debug ("    critical=%ld", (long) self->critical);
+            zsys_debug ("    severity=%ld", (long) self->severity);
             zsys_debug ("    description='%s'", self->description);
             break;
 
@@ -831,38 +825,20 @@ zm_proto_set_rule (zm_proto_t *self, const char *value)
 
 
 //  --------------------------------------------------------------------------
-//  Get/set the active field
+//  Get/set the severity field
 
 byte
-zm_proto_active (zm_proto_t *self)
+zm_proto_severity (zm_proto_t *self)
 {
     assert (self);
-    return self->active;
+    return self->severity;
 }
 
 void
-zm_proto_set_active (zm_proto_t *self, byte active)
+zm_proto_set_severity (zm_proto_t *self, byte severity)
 {
     assert (self);
-    self->active = active;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Get/set the critical field
-
-byte
-zm_proto_critical (zm_proto_t *self)
-{
-    assert (self);
-    return self->critical;
-}
-
-void
-zm_proto_set_critical (zm_proto_t *self, byte critical)
-{
-    assert (self);
-    self->critical = critical;
+    self->severity = severity;
 }
 
 
@@ -962,8 +938,7 @@ zm_proto_test (bool verbose)
     zhash_insert (alert_ext, "Name", "Brutus");
     zm_proto_set_ext (self, &alert_ext);
     zm_proto_set_rule (self, "Life is short but Now lasts for ever");
-    zm_proto_set_active (self, 123);
-    zm_proto_set_critical (self, 123);
+    zm_proto_set_severity (self, 123);
     zm_proto_set_description (self, "Life is short but Now lasts for ever");
     zmsg_destroy (&output);
     output = zmsg_new ();
@@ -989,8 +964,7 @@ zm_proto_test (bool verbose)
         if (instance == 1)
             zhash_destroy (&alert_ext);
         assert (streq (zm_proto_rule (self), "Life is short but Now lasts for ever"));
-        assert (zm_proto_active (self) == 123);
-        assert (zm_proto_critical (self) == 123);
+        assert (zm_proto_severity (self) == 123);
         assert (streq (zm_proto_description (self), "Life is short but Now lasts for ever"));
     }
     zm_proto_set_id (self, ZM_PROTO_DEVICE);

--- a/src/zm_proto.xml
+++ b/src/zm_proto.xml
@@ -59,12 +59,8 @@
         Identifier of the rule which triggers this alert.
     </field>
 
-    <field name = "active" type = "number" size = "1">
-        Alert is active (value 1) or resolved (value 0).
-    </field>
-
-    <field name = "critical" type = "number" size = "1">
-        Alert is critical (value 1) or not (value 0).
+    <field name = "severity" type = "number" size = "1">
+        Alert is present and critical (value > 0) or resolved (value 0).
     </field>
 
     <field name = "description" type = "string">

--- a/src/zm_proto_utils.c
+++ b/src/zm_proto_utils.c
@@ -212,6 +212,41 @@ zm_proto_encode_device (
 
     zm_proto_t *self = s_zm_proto_encode_common (device, time, ttl, ext);
     zm_proto_set_id (self, ZM_PROTO_DEVICE);
+
+    zmsg_t *output = zmsg_new ();
+    assert (output);
+    if (zm_proto_send (self, output) == 0) {
+        zm_proto_destroy (&self);
+        return output;
+    } else {
+        zm_proto_destroy (&self);
+        zmsg_destroy (&output);
+        return NULL;
+    }
+}
+
+//  --------------------------------------------------------------------------
+//  v1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
+
+zmsg_t *
+zm_proto_encode_alert (
+    const char *device,
+    int64_t time,
+    int32_t ttl,
+    zhash_t *ext,
+    const char *rule,
+    char severity,
+    const char *description
+)
+{
+    if (!device || !rule) return NULL;
+
+    zm_proto_t *self = s_zm_proto_encode_common (device, time, ttl, ext);
+    zm_proto_set_id (self, ZM_PROTO_ALERT);
+    zm_proto_set_rule (self, rule);
+    zm_proto_set_severity (self, severity);
+    zm_proto_set_description (self, description);
+
     zmsg_t *output = zmsg_new ();
     assert (output);
     if (zm_proto_send (self, output) == 0) {

--- a/src/zm_proto_utils.c
+++ b/src/zm_proto_utils.c
@@ -226,7 +226,7 @@ zm_proto_encode_device (
 }
 
 //  --------------------------------------------------------------------------
-//  v1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
+//  v1 codec compatibility function, creates zm_proto_t with alert and encode it to zmsg_t
 
 zmsg_t *
 zm_proto_encode_alert (

--- a/src/zmpub.c
+++ b/src/zmpub.c
@@ -2,11 +2,11 @@
     zmpub - Helper tool to publish zm-proto messages on a stream
 
     Copyright (c) the Contributors as noted in the AUTHORS file.  This file is part
-    of zmon.it, the fast and scalable monitoring system.                           
-                                                                                   
+    of zmon.it, the fast and scalable monitoring system.
+
     This Source Code Form is subject to the terms of the Mozilla Public License, v.
-    2.0. If a copy of the MPL was not distributed with this file, You can obtain   
-    one at http://mozilla.org/MPL/2.0/.                                            
+    2.0. If a copy of the MPL was not distributed with this file, You can obtain
+    one at http://mozilla.org/MPL/2.0/.
     =========================================================================
 */
 
@@ -188,7 +188,7 @@ int main (int argc, char *argv [])
         puts ("  --verbose / -v         verbose test output");
         puts ("  --help / -h            this information");
         puts ("");
-        puts ("                alert device ttl type rule state severity description");
+        puts ("                alert device ttl rule severity description");
         puts ("                device device ttl");
         puts ("                metric device ttl type value unit");
         return 0;
@@ -267,16 +267,10 @@ int main (int argc, char *argv [])
         }
         const char *rule = zargs_next (args);
 
-        bool active = false;
-        foo = zargs_next (args);
-        if (strcaseq (foo, "active")) {
-            active = true;
-        }
-
-        bool critical = false;
+        char severity = 0;
         foo = zargs_next (args);
         if (strcaseq (foo, "critical")) {
-            active = true;
+            severity = 1;
         }
 
         const char *description = zargs_next (args);
@@ -288,8 +282,7 @@ int main (int argc, char *argv [])
 
         zm_proto_set_ttl (msg, ttl);
         zm_proto_set_rule (msg, rule);
-        zm_proto_set_active (msg, active ? 1 : 0);
-        zm_proto_set_critical (msg, critical ? 1 : 0);
+        zm_proto_set_severity (msg, severity);
         zm_proto_set_description (msg, description);
     }
     else


### PR DESCRIPTION
Solution: Keep only severity. Alert rule returns severity 0 when
alert is resolved.
