### PR TITLE
Problem: can't easily encode zm_proto_t to store it in hash

### DIFF
--- a/include/zm_proto.h
+++ b/include/zm_proto.h
@@ -49,6 +49,20 @@
         time                number 8    Time when message was generated
         ttl                 number 4    Time to live, after $current time > time - ttl, message is droped
         ext                 hash        Additional extended informations for the message
+
+    OK - 
+        device              string      Device universal unique identifier
+        time                number 8    Time when message was generated
+        ttl                 number 4    Time to live, after $current time > time - ttl, message is droped
+        ext                 hash        Additional extended informations for the message
+
+    ERROR - 
+        device              string      Device universal unique identifier
+        time                number 8    Time when message was generated
+        ttl                 number 4    Time to live, after $current time > time - ttl, message is droped
+        ext                 hash        Additional extended informations for the message
+        code                number 2    (HTTP?) Error code
+        description         string      Error description.
 */
 
 #define ZM_PROTO_METRIC_STREAM              "METRICS"
@@ -58,6 +72,8 @@
 #define ZM_PROTO_METRIC                     1
 #define ZM_PROTO_ALERT                      2
 #define ZM_PROTO_DEVICE                     3
+#define ZM_PROTO_OK                         4
+#define ZM_PROTO_ERROR                      5
 
 #include <czmq.h>
 
@@ -184,6 +200,12 @@ const char *
     zm_proto_description (zm_proto_t *self);
 void
     zm_proto_set_description (zm_proto_t *self, const char *value);
+
+//  Get/set the code field
+uint16_t
+    zm_proto_code (zm_proto_t *self);
+void
+    zm_proto_set_code (zm_proto_t *self, uint16_t code);
 
 //  Self test of this class
 void

--- a/include/zm_proto_utils.h
+++ b/include/zm_proto_utils.h
@@ -116,6 +116,14 @@ ZM_PROTO_EXPORT void
         const char *description
     );
 
+//  Encode OK message
+ZM_PROTO_EXPORT void
+    zm_proto_encode_ok (zm_proto_t *self);
+
+//  Encode ERROR message
+ZM_PROTO_EXPORT void
+    zm_proto_encode_error (zm_proto_t *self, uint32_t code, const char *description);
+
 //  Self test of this class
 ZM_PROTO_EXPORT void
     zm_proto_utils_test (bool verbose);

--- a/src/zm_proto.bnf
+++ b/src/zm_proto.bnf
@@ -1,6 +1,6 @@
 The following ABNF grammar defines the Basic messaging for zmon.it:
 
-    zm_proto        = *( METRIC | ALERT | DEVICE )
+    zm_proto        = *( METRIC | ALERT | DEVICE | OK | ERROR )
 
     ;  No description                                                        
 
@@ -33,6 +33,24 @@ The following ABNF grammar defines the Basic messaging for zmon.it:
     ttl             = number-4              ; Time to live, after $current time > time - ttl, message is droped
     ext             = hash                  ; Additional extended informations for the message
 
+    ;  No description                                                        
+
+    OK              = signature %d4 device time ttl ext
+    device          = string                ; Device universal unique identifier
+    time            = number-8              ; Time when message was generated
+    ttl             = number-4              ; Time to live, after $current time > time - ttl, message is droped
+    ext             = hash                  ; Additional extended informations for the message
+
+    ;  No description                                                        
+
+    ERROR           = signature %d5 device time ttl ext code description
+    device          = string                ; Device universal unique identifier
+    time            = number-8              ; Time when message was generated
+    ttl             = number-4              ; Time to live, after $current time > time - ttl, message is droped
+    ext             = hash                  ; Additional extended informations for the message
+    code            = number-2              ; (HTTP?) Error code
+    description     = string                ; Error description.
+
     ; A list of name/value pairs
     hash            = hash-count *( hash-name hash-value )
     hash-count      = number-4
@@ -45,5 +63,6 @@ The following ABNF grammar defines the Basic messaging for zmon.it:
 
     ; Numbers are unsigned integers in network byte order
     number-1        = 1OCTET
+    number-2        = 2OCTET
     number-4        = 4OCTET
     number-8        = 8OCTET

--- a/src/zm_proto.xml
+++ b/src/zm_proto.xml
@@ -73,4 +73,19 @@
     id = "3">
 </message>
 
+<!-- fore REQ/REP pattern -->
+<message name = "OK" id = "4" />
+
+<message
+    name = "ERROR"
+    id = "5"
+    >
+    <field name = "code" type = "number" size = "4">
+        (HTTP?) Error code
+    </field>
+    <field name = "description" type = "string">
+        Error description.
+    </field>
+</message>
+
 </class>

--- a/src/zm_proto_utils.c
+++ b/src/zm_proto_utils.c
@@ -158,9 +158,9 @@ s_zm_proto_encode_common (
         zm_proto_set_ext (self, &d);
     }
     else {
-        zhash_t *ext = zm_proto_ext (self);
-        zhash_destroy (&ext);
-        zm_proto_set_ext (self, NULL);
+        zhash_t *new_ext = zhash_new ();
+        zhash_autofree (new_ext);
+        zm_proto_set_ext (self, &new_ext);
     }
         
     return self;

--- a/src/zm_proto_utils.c
+++ b/src/zm_proto_utils.c
@@ -303,6 +303,24 @@ zm_proto_encode_alert_v1 (
 
 }
 
+void
+zm_proto_encode_ok (zm_proto_t *self)
+{
+    assert (self);
+
+    s_zm_proto_encode_common (self, ZM_PROTO_OK, NULL, 0, 0, NULL);
+}
+
+void
+zm_proto_encode_error (zm_proto_t *self, uint32_t code, const char *description)
+{
+    assert (self);
+
+    s_zm_proto_encode_common (self, ZM_PROTO_ERROR, NULL, 0, 0, NULL);
+    zm_proto_set_code (self, code);
+    zm_proto_set_description (self, description);
+}
+
 //  --------------------------------------------------------------------------
 //  Self test of this class
 


### PR DESCRIPTION
And does not support an allocation-free style of using zproto_codec_c

Solution:
 * mark existing functions as _v1 to make explicit they're for compatibility
   reasons and will be eventually dropped
   (maybe move them to deprecated class?)
 * add new encode functions, which does NOT allocate extra message
 * refactor _v1 functions to use new encode methods