### PR TITLE
Problem: can't build redhat package because invalid path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -478,6 +478,9 @@ case "${host_os}" in
         AC_DEFINE(ZM_PROTO_HAVE_HPUX, 1, [Have HPUX OS])
         ;;
     *mingw32*)
+        # Disable format error due to incomplete ANSI C
+        CFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CFLAGS"
+        CPPFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CPPFLAGS"
         AC_DEFINE(ZM_PROTO_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(ZM_PROTO_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)
@@ -487,7 +490,8 @@ case "${host_os}" in
     *mingw64*)
         # Define on MINGW64 to enable all libeary features
         # Disable format error due to incomplete ANSI C
-        CPPFLAGS="-Wno-error=format -D_XOPEN_SOURCE $CPPFLAGS"
+        CFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CFLAGS"
+        CPPFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CPPFLAGS"
         AC_DEFINE(ZM_PROTO_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(ZM_PROTO_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)

--- a/packaging/debian/libzm-proto-dev.manpages
+++ b/packaging/debian/libzm-proto-dev.manpages
@@ -1,2 +1,2 @@
-usr/share/man/man3/*
-usr/share/man/man7/*
+debian/tmp/usr/share/man/man3/*
+debian/tmp/usr/share/man/man7/*

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -44,7 +44,7 @@ endif
 endif
 
 ifeq (yes,$(PYTHON_CFFI))
-export PYBUILD_NAME=czmq-cffi
+export PYBUILD_NAME=zm-proto-cffi
 export PKG_CONFIG_PATH=$(CURDIR)/bindings/python_cffi:$PKG_CONFIG_PATH
 
 override_dh_auto_build:

--- a/packaging/debian/zm-proto.manpages
+++ b/packaging/debian/zm-proto.manpages
@@ -1,2 +1,2 @@
-usr/share/man/man1/zmpub.1
-usr/share/man/man1/zmsub.1
+debian/tmp/usr/share/man/man1/zmpub.1
+debian/tmp/usr/share/man/man1/zmsub.1

--- a/packaging/redhat/zm-proto.spec
+++ b/packaging/redhat/zm-proto.spec
@@ -109,8 +109,8 @@ Requires:  python = %{py2_ver}
 This package contains Python CFFI bindings for zm-proto
 
 %files -n python2-zm-proto_cffi
-%{_libdir}/python%{py2_ver}/site-packages/zm-proto_cffi/
-%{_libdir}/python%{py2_ver}/site-packages/zm-proto_cffi-*-py%{py2_ver}.egg-info/
+%{_libdir}/python%{py2_ver}/site-packages/zm_proto_cffi/
+%{_libdir}/python%{py2_ver}/site-packages/zm_proto_cffi-*-py%{py2_ver}.egg-info/
 
 %package -n python3-zm-proto_cffi
 Group:  Python
@@ -121,8 +121,8 @@ Requires:  python3 = %{py2_ver}
 This package contains Python 3 CFFI bindings for zm-proto
 
 %files -n python3-zm-proto_cffi
-%{_libdir}/python%{py3_ver}/site-packages/zm-proto_cffi/
-%{_libdir}/python%{py3_ver}/site-packages/zm-proto_cffi-*-py%{py3_ver}.egg-info/
+%{_libdir}/python%{py3_ver}/site-packages/zm_proto_cffi/
+%{_libdir}/python%{py3_ver}/site-packages/zm_proto_cffi-*-py%{py3_ver}.egg-info/
 %endif
 
 %prep


### PR DESCRIPTION
Solution: regenerate using latest zproject, got correct paths of python modules