### PR TITLE
Problem: cannot use utils functions from Python

### DIFF
--- a/api/zm_proto.api
+++ b/api/zm_proto.api
@@ -188,4 +188,151 @@
     Set the code field
     <argument name = "code" type = "number" size = "4" />
 </method>
+
+<!--
+    MANUALLY ADDED methods, please re-add them on change
+    those are defined in include/zm_proto_utils.h, however are
+    methods of zm_proto itself. However it is not possible in API
+    model to express such posibility.
+-->
+<method name = "ext string">
+    Get string from ext attribute
+    <argument name = "name" type = "string"/>
+    <argument name = "dflt" type = "string" />
+    <return type = "string" />
+</method>
+
+<method name = "ext set string">
+    Set ext attribute
+    <argument name = "name" type = "string"/>
+    <argument name = "value" type = "string" />
+</method>
+
+<method name = "ext number">
+    Get a number
+    <argument name = "name" type = "string" />
+    <argument name = "dflt" type = "number" size = "8" />
+    <return type = "number" size = "8" />
+</method>
+
+<method name = "ext set number">
+    Set a number
+    <argument name = "name" type = "string" />
+    <argument name = "value" type = "number" size = "8" />
+</method>
+
+<method name = "ext double">
+    Get a number
+    <argument name = "name" type = "string" />
+    <argument name = "dflt" type = "real" size = "8" />
+    <return type = "real" size = "8" />
+</method>
+
+<method name = "ext set double">
+    Set a number
+    <argument name = "name" type = "string" />
+    <argument name = "value" type = "real" size = "8" />
+</method>
+
+
+<method name = "decode" singleton = "1" >
+    Converts zmsg to zm_proto, this is for compatibility with zproto v1 codec
+    <argument name = "msg_p" type = "zmsg" by_reference = "1" />
+    <return type = "zm_proto" fresh = "1" />
+</method>
+
+<method name = "encode metric v1" singleton = "1">
+    V1 codec compatibility function, creates zm_proto_t with metric and encode it to zmsg_t
+    <argument name = "device" type = "string" />
+    <argument name = "time" type = "number" size = "8" />
+    <argument name = "ttl" type = "number" size = "4" />
+    <argument name = "ext" type = "zhash" />
+    <argument name = "type" type = "string" />
+    <argument name = "value" type = "string" />
+    <argument name = "units" type = "string" />
+    <return type = "zmsg" fresh = "1" />
+</method>
+
+<method name = "encode device v1" singleton = "1">
+    V1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
+    <argument name = "device" type = "string" />
+    <argument name = "time" type = "number" size = "8" />
+    <argument name = "ttl" type = "number" size = "4" />
+    <argument name = "ext" type = "zhash" />
+    <return type = "zmsg" fresh = "1" />
+</method>
+
+<method name = "encode alert v1" singleton = "1">
+    V1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
+    <argument name = "device" type = "string" />
+    <argument name = "time" type = "number" size = "8" />
+    <argument name = "ttl" type = "number" size = "4" />
+    <argument name = "ext" type = "zhash" />
+    <argument name = "rule" type = "string" />
+    <argument name = "severity" type = "number" size = "1" />
+    <argument name = "description" type = "string" />
+    <return type = "zmsg" fresh = "1" />
+</method>
+
+<method name = "encode metric">
+    Set zm_proto_t as metric
+    <argument name = "device" type = "string" />
+    <argument name = "time" type = "number" size = "8" />
+    <argument name = "ttl" type = "number" size = "4" />
+    <argument name = "ext" type = "zhash" />
+    <argument name = "type" type = "string" />
+    <argument name = "value" type = "string" />
+    <argument name = "units" type = "string" />
+</method>
+
+<method name = "encode device">
+    Set zm_proto_t as device
+    <argument name = "device" type = "string" />
+    <argument name = "time" type = "number" size = "8" />
+    <argument name = "ttl" type = "number" size = "4" />
+    <argument name = "ext" type = "zhash" />
+</method>
+
+<method name = "encode alert">
+    Set zm_proto_t as alert
+    <argument name = "device" type = "string" />
+    <argument name = "time" type = "number" size = "8" />
+    <argument name = "ttl" type = "number" size = "4" />
+    <argument name = "ext" type = "zhash" />
+    <argument name = "rule" type = "string" />
+    <argument name = "severity" type = "number" size = "1" />
+    <argument name = "description" type = "string" />
+</method>
+
+<method name = "encode ok">
+    Set zm_proto_t as OK
+</method>
+
+<method name = "encode error">
+    Set zm_proto_t as OK
+    <argument name = "code" type = "number" size = "4" />
+    <argument name = "description" type = "string" />
+</method>
+
+<method name = "send mlm">
+    Send STREAM DELIVER zm_proto_t message using mlm_client
+    <argument name = "client" type = "mlm_client" />
+    <argument name = "subject" type = "string" />
+    <return type = "integer" />
+</method>
+
+<method name = "sendto">
+    Send MAILBOX DELIVER zm_proto_t message using mlm_client
+    <argument name = "client" type = "mlm_client" />
+    <argument name = "address" type = "string" />
+    <argument name = "subject" type = "string" />
+    <return type = "integer" />
+</method>
+
+<method name = "recv mlm">
+    Receive zm_proto_t from mlm_client, return -1 and do not touch zm_proto_t
+    if zm_proto_t was NOT delivered
+    <argument name = "client" type = "mlm_client" />
+    <return type = "integer" />
+</method>
 </class>

--- a/bindings/python_cffi/zm_proto_cffi/__init__.py
+++ b/bindings/python_cffi/zm_proto_cffi/__init__.py
@@ -3,11 +3,11 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 try:
-    import native
+    from . import native
     lib = native.lib
     ffi = native.ffi
 except ImportError:
-    import dlopen
+    from . import dlopen
     lib = dlopen.lib
     ffi = dlopen.ffi
 

--- a/bindings/python_cffi/zm_proto_cffi/cdefs.py
+++ b/bindings/python_cffi/zm_proto_cffi/cdefs.py
@@ -14,6 +14,7 @@ typedef struct _zconfig_t zconfig_t;
 typedef struct _zmsg_t zmsg_t;
 typedef struct _zframe_t zframe_t;
 typedef struct _zhash_t zhash_t;
+typedef struct _mlm_client_t mlm_client_t;
 // CLASS: zm_proto
 // Create a new empty zm_proto
 zm_proto_t *
@@ -159,6 +160,79 @@ uint32_t
 // Set the code field
 void
     zm_proto_set_code (zm_proto_t *self, uint32_t code);
+
+// Get string from ext attribute
+const char *
+    zm_proto_ext_string (zm_proto_t *self, const char *name, const char *dflt);
+
+// Set ext attribute
+void
+    zm_proto_ext_set_string (zm_proto_t *self, const char *name, const char *value);
+
+// Get a number
+uint64_t
+    zm_proto_ext_number (zm_proto_t *self, const char *name, uint64_t dflt);
+
+// Set a number
+void
+    zm_proto_ext_set_number (zm_proto_t *self, const char *name, uint64_t value);
+
+// Get a number
+double
+    zm_proto_ext_double (zm_proto_t *self, const char *name, double dflt);
+
+// Set a number
+void
+    zm_proto_ext_set_double (zm_proto_t *self, const char *name, double value);
+
+// Converts zmsg to zm_proto, this is for compatibility with zproto v1 codec
+zm_proto_t *
+    zm_proto_decode (zmsg_t **msg_p);
+
+// V1 codec compatibility function, creates zm_proto_t with metric and encode it to zmsg_t
+zmsg_t *
+    zm_proto_encode_metric_v1 (const char *device, uint64_t time, uint32_t ttl, zhash_t *ext, const char *type, const char *value, const char *units);
+
+// V1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
+zmsg_t *
+    zm_proto_encode_device_v1 (const char *device, uint64_t time, uint32_t ttl, zhash_t *ext);
+
+// V1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
+zmsg_t *
+    zm_proto_encode_alert_v1 (const char *device, uint64_t time, uint32_t ttl, zhash_t *ext, const char *rule, uint8_t severity, const char *description);
+
+// Set zm_proto_t as metric
+void
+    zm_proto_encode_metric (zm_proto_t *self, const char *device, uint64_t time, uint32_t ttl, zhash_t *ext, const char *type, const char *value, const char *units);
+
+// Set zm_proto_t as device
+void
+    zm_proto_encode_device (zm_proto_t *self, const char *device, uint64_t time, uint32_t ttl, zhash_t *ext);
+
+// Set zm_proto_t as alert
+void
+    zm_proto_encode_alert (zm_proto_t *self, const char *device, uint64_t time, uint32_t ttl, zhash_t *ext, const char *rule, uint8_t severity, const char *description);
+
+// Set zm_proto_t as OK
+void
+    zm_proto_encode_ok (zm_proto_t *self);
+
+// Set zm_proto_t as OK
+void
+    zm_proto_encode_error (zm_proto_t *self, uint32_t code, const char *description);
+
+// Send STREAM DELIVER zm_proto_t message using mlm_client
+int
+    zm_proto_send_mlm (zm_proto_t *self, mlm_client_t *client, const char *subject);
+
+// Send MAILBOX DELIVER zm_proto_t message using mlm_client
+int
+    zm_proto_sendto (zm_proto_t *self, mlm_client_t *client, const char *address, const char *subject);
+
+// Receive zm_proto_t from mlm_client, return -1 and do not touch zm_proto_t
+// if zm_proto_t was NOT delivered                                          
+int
+    zm_proto_recv_mlm (zm_proto_t *self, mlm_client_t *client);
 
 // Self test of this class.
 void

--- a/include/zm_proto_utils.h
+++ b/include/zm_proto_utils.h
@@ -16,130 +16,17 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 //  @interface
-//  Get string item from ext attribute
-ZM_PROTO_EXPORT const char *
-    zm_proto_ext_string (zm_proto_t *self, const char *name, const char *dflt);
 
-//  Set string item in ext attribute
-ZM_PROTO_EXPORT void
-    zm_proto_ext_set_string (zm_proto_t *self, const char *name, const char *value);
+/*XXX: does not work!
+#define zm_proto_ext_set_int(self, name, value) \
+    zm_proto_ext_set_number (self, name, (uint64_t) value)
+#define zm_proto_ext_int(self, name, dflt) \
+    (int) zm_proto_ext_number (self, name, (uint64_t) dflt)
+*/
 
-//  Get long int item from ext attribute
-ZM_PROTO_EXPORT long int
-    zm_proto_ext_int (zm_proto_t *self, const char *name, long int dflt);
-
-//  Set long int item in ext attribute
-ZM_PROTO_EXPORT void
-    zm_proto_ext_set_int (zm_proto_t *self, const char *name, long int value);
-
-//  Get double item from ext attribute
-ZM_PROTO_EXPORT double
-    zm_proto_ext_double (zm_proto_t *self, const char *name, double dflt);
-
-//  Set double item in ext attribute
-ZM_PROTO_EXPORT void
-    zm_proto_ext_set_double (zm_proto_t *self, const char *name, double value);
-
-//  Converts zmsg to zm_proto, this is for compatibility with zproto v1 codec
-ZM_PROTO_EXPORT zm_proto_t *
-    zm_proto_decode (zmsg_t **message_p);
-
-//  v1 codec compatibility function, creates zm_proto_t with metric and encode it to zmsg_t
-ZM_PROTO_EXPORT zmsg_t *
-    zm_proto_encode_metric_v1 (
-        const char *device,
-        int64_t time,
-        int32_t ttl,
-        zhash_t *ext,
-        const char *type,
-        const char *value,
-        const char *units
-    );
-
-//  v1 codec compatibility function, creates zm_proto_t with device and encode it to zmsg_t
-ZM_PROTO_EXPORT zmsg_t *
-    zm_proto_encode_device_v1 (
-        const char *device,
-        int64_t time,
-        int32_t ttl,
-        zhash_t *ext
-    );
-
-
-//  v1 codec compatibility function, creates zm_proto_t with alert and encode it to zmsg_t
-ZM_PROTO_EXPORT zmsg_t *
-    zm_proto_encode_alert_v1 (
-        const char *device,
-        int64_t time,
-        int32_t ttl,
-        zhash_t *ext,
-        const char *rule,
-        char severity,
-        const char *description
-    );
-
-//  encode metric
-ZM_PROTO_EXPORT void
-    zm_proto_encode_metric (
-        zm_proto_t *self,
-        const char *device,
-        int64_t time,
-        int32_t ttl,
-        zhash_t *ext,
-        const char *type,
-        const char *value,
-        const char *units
-    );
-
-//  encode device
-ZM_PROTO_EXPORT void
-    zm_proto_encode_device (
-        zm_proto_t *self,
-        const char *device,
-        int64_t time,
-        int32_t ttl,
-        zhash_t *ext
-    );
-
-//  encode device
-ZM_PROTO_EXPORT void
-    zm_proto_encode_alert (
-        zm_proto_t *self,
-        const char *device,
-        int64_t time,
-        int32_t ttl,
-        zhash_t *ext,
-        const char *rule,
-        char severity,
-        const char *description
-    );
-
-//  Encode OK message
-ZM_PROTO_EXPORT void
-    zm_proto_encode_ok (zm_proto_t *self);
-
-//  Encode ERROR message
-ZM_PROTO_EXPORT void
-    zm_proto_encode_error (zm_proto_t *self, uint32_t code, const char *description);
-
-//  Self test of this class
-ZM_PROTO_EXPORT void
+void
     zm_proto_utils_test (bool verbose);
-
-//  Send STREAM DELIVER zm_proto_t message via mlm_client
-ZM_PROTO_EXPORT int
-    zm_proto_send_mlm (zm_proto_t *self, mlm_client_t *client, const char *subject);
-
-//  Send MAILBOX DELIVER zm_proto_t message via mlm_client
-ZM_PROTO_EXPORT int
-    zm_proto_sendto (zm_proto_t *self, mlm_client_t *client, const char *address, const char *subject);
-
-//  Receive zm_proto_t from mlm_client, return -1 and do not touch zm_proto_t
-//  if zm_proto_t was NOT delivered
-ZM_PROTO_EXPORT int
-    zm_proto_recv_mlm (zm_proto_t *self, mlm_client_t *client);
 
 //  @end
 

--- a/packaging/redhat/zm-proto.spec
+++ b/packaging/redhat/zm-proto.spec
@@ -115,7 +115,7 @@ This package contains Python CFFI bindings for zm-proto
 %package -n python3-zm-proto-cffi
 Group:  Python
 Summary:    Python 3 CFFI bindings for zm-proto
-Requires:  python3 = %{py2_ver}
+Requires:  python3 = %{py3_ver}
 
 %description -n python3-zm-proto-cffi
 This package contains Python 3 CFFI bindings for zm-proto

--- a/src/zm_proto_utils.c
+++ b/src/zm_proto_utils.c
@@ -52,8 +52,8 @@ void zm_proto_ext_set_string (zm_proto_t *self, const char *name, const char *va
 //  --------------------------------------------------------------------------
 //  Get long int item from ext attribute
 
-long int
-zm_proto_ext_int (zm_proto_t *self, const char *name, long int dflt)
+uint64_t
+zm_proto_ext_number (zm_proto_t *self, const char *name, uint64_t dflt)
 {
     const char *value = zm_proto_ext_string (self, name, NULL);
     if (! value) return dflt;
@@ -75,12 +75,13 @@ zm_proto_ext_int (zm_proto_t *self, const char *name, long int dflt)
 //  Set long int item in ext attribute
 
 void
-zm_proto_ext_set_int (zm_proto_t *self, const char *name, long int value)
+zm_proto_ext_set_number (zm_proto_t *self, const char *name, uint64_t value)
 {
-    int size = snprintf(NULL, 0, "%li", value);
+    zsys_debug ("set_number: uint64_t %" PRIu64 ", ld=%ld", value, (long int) value);
+    int size = snprintf(NULL, 0, "%" PRIu64, value);
 
     char buffer [size+1];
-    snprintf(buffer, size + 1, "%li", value);
+    snprintf(buffer, size + 1, "%" PRIu64, value);
     zm_proto_ext_set_string (self, name, buffer);
 }
 
@@ -143,8 +144,8 @@ s_zm_proto_encode_common (
     zm_proto_t *self,
     int id,
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext
 )
 {
@@ -192,8 +193,8 @@ void
 zm_proto_encode_metric (
     zm_proto_t *self,
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext,
     const char *type,
     const char *value,
@@ -215,8 +216,8 @@ void
 zm_proto_encode_device(
     zm_proto_t *self,
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext
 )
 {
@@ -228,11 +229,11 @@ void
 zm_proto_encode_alert (
     zm_proto_t *self,
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext,
     const char *rule,
-    char severity,
+    uint8_t severity,
     const char *description
 )
 {
@@ -249,8 +250,8 @@ zm_proto_encode_alert (
 zmsg_t *
 zm_proto_encode_metric_v1 (
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext,
     const char *type,
     const char *value,
@@ -269,8 +270,8 @@ zm_proto_encode_metric_v1 (
 zmsg_t *
 zm_proto_encode_device_v1(
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext
 )
 {
@@ -286,11 +287,11 @@ zm_proto_encode_device_v1(
 zmsg_t *
 zm_proto_encode_alert_v1 (
     const char *device,
-    int64_t time,
-    int32_t ttl,
+    uint64_t time,
+    uint32_t ttl,
     zhash_t *ext,
     const char *rule,
-    char severity,
+    uint8_t severity,
     const char *description
 )
 {
@@ -398,14 +399,14 @@ zm_proto_utils_test (bool verbose)
         zm_proto_ext_set_string (self, "something", "nothing");
         assert (streq (zm_proto_ext_string (self, "something", "value"), "nothing"));
 
-        zm_proto_ext_set_int (self, "num", -45);
-        assert (zm_proto_ext_int (self, "num", 0) == -45);
+        zm_proto_ext_set_number (self, "num", 42);
+        assert (zm_proto_ext_number (self, "num", 0) == 42);
 
         zm_proto_ext_set_double (self, "pi", 3.14159);
         assert (zm_proto_ext_double (self, "pi", 0) == 3.14159);
 
         zm_proto_ext_set_string (self, "errnum", "3invalid");
-        assert (zm_proto_ext_int (self, "errnum", -1) == -1);
+        assert (zm_proto_ext_number (self, "errnum", 0) == 0);
         assert (zm_proto_ext_double (self, "errnum", -1.0) == -1.0);
 
         zm_proto_print (self);


### PR DESCRIPTION
Solution:
 1. write API model for methods
 2. convert incompatible methods to model compatible ones (especially types)
 3. regenerate using latest gsl to get cdefs, and some other fixes

@thalman I removed int functions, we will need to find a way how to deal with those ...